### PR TITLE
Upgrade Android Braintree SDK to version 4.27.2

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,13 +86,12 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'com.google.android.gms:play-services-wallet:18.1.3'
-    implementation 'com.braintreepayments.api:data-collector:4.21.0'
-    implementation 'com.braintreepayments.api:google-pay:4.21.0'
-    implementation 'com.braintreepayments.api:paypal:4.21.0'
-    implementation 'com.braintreepayments.api:three-d-secure:4.21.0'
-    implementation 'com.braintreepayments.api:card:4.21.0'
-    implementation 'com.braintreepayments.api:three-d-secure:4.21.0'
-
+    implementation 'com.braintreepayments.api:data-collector:4.27.2'
+    implementation 'com.braintreepayments.api:google-pay:4.27.2'
+    implementation 'com.braintreepayments.api:paypal:4.27.2'
+    implementation 'com.braintreepayments.api:three-d-secure:4.27.2'
+    implementation 'com.braintreepayments.api:card:4.27.2'
+    implementation 'com.braintreepayments.api:three-d-secure:4.27.2'
 }
 
 def configureReactNativePom(def pom) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ekreative/react-native-braintree",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ekreative/react-native-braintree",
   "title": "React Native Braintree",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TODO",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
It would be good to upgrade Android Braintree SDK to the latest version as it contains some bugfixes
Seems like there are no breaking changes for us - https://github.com/braintree/braintree_android/blob/master/CHANGELOG.md