### PR TITLE
Feature: add native `getDeviceData` method

### DIFF
--- a/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
+++ b/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
@@ -370,18 +370,18 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
                     mCurrentActivity,
                     threeDSecureRequest,
                     (threeDSecureResult, error) -> {
-                if (error != null) {
-                    handleError(error);
-                    return;
-                }
-                if (threeDSecureResult != null) {
-                    mThreeDSecureClient.continuePerformVerification(
+                        if (error != null) {
+                            handleError(error);
+                            return;
+                        }
+                        if (threeDSecureResult != null) {
+                            mThreeDSecureClient.continuePerformVerification(
                                     mCurrentActivity,
                                     threeDSecureRequest,
                                     threeDSecureResult,
                                     this::handleThreeDSecureResult);
-                }
-            });
+                        }
+                    });
         }
     }
 

--- a/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
+++ b/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
@@ -370,20 +370,29 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
                     mCurrentActivity,
                     threeDSecureRequest,
                     (threeDSecureResult, error) -> {
-                        if (error != null) {
-                            handleError(error);
-                            return;
-                        }
-                        if (threeDSecureResult != null) {
-                            mThreeDSecureClient.continuePerformVerification(
+                if (error != null) {
+                    handleError(error);
+                    return;
+                }
+                if (threeDSecureResult != null) {
+                    mThreeDSecureClient.continuePerformVerification(
                                     mCurrentActivity,
                                     threeDSecureRequest,
                                     threeDSecureResult,
                                     this::handleThreeDSecureResult);
-                        }
-                    });
+                }
+            });
         }
     }
+
+    @ReactMethod
+    public void getDeviceData(final String clientToken, final Promise promise) {
+        setup(clientToken);
+        new DataCollector(mBraintreeClient).collectDeviceData(
+                mContext,
+                (result, e) -> promise.resolve(result));
+    }
+
 
     private void handleThreeDSecureResult(ThreeDSecureResult threeDSecureResult, Exception error) {
         if (error != null) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ declare module '@ekreative/react-native-braintree' {
     tokenizeCard(options: TokenizeCardOptions): Promise<BraintreeResponse>;
     runApplePay(options: RunApplePayOptions): Promise<BraintreeResponse>;
     requestPayPalBillingAgreement(options: PayPalBillingAgreementOptions): Promise<BraintreeResponse>;
+    getDeviceData(clientToken: string): Promise<string>;
   }
 
   const RNBraintree: RNBraintreeModule;

--- a/index.js
+++ b/index.js
@@ -12,4 +12,5 @@ export default {
     tokenizeCard: RNBraintree.tokenizeCard,
     runApplePay: RNBraintreeApplePay && RNBraintreeApplePay.runApplePay,
     requestPayPalBillingAgreement: RNBraintree.requestPayPalBillingAgreement,
+    getDeviceData: RNBraintree.getDeviceData,
 }

--- a/ios/RNBraintree.m
+++ b/ios/RNBraintree.m
@@ -112,6 +112,16 @@ RCT_EXPORT_METHOD(run3DSecureCheck: (NSDictionary *)parameters
                   rejecter:reject];
 }
 
+RCT_EXPORT_METHOD(getDeviceData: (NSString *) clientToken
+                  resolver: (RCTPromiseResolveBlock)resolve
+                  rejecter: (RCTPromiseRejectBlock)reject) {
+    self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
+    self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];
+    [self.dataCollector collectDeviceData:^(NSString * _Nonnull deviceData) {
+        resolve(deviceData);
+    }];
+}
+
 #pragma mark - 3D Secure
 - (void)startPaymentFlow: (NSDictionary *)parameters
                 resolver: (RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
There was no way to get device data from BrainTree without calling native payment flow methods like `showPaypalModule()` or `tokenizeCard()`. Device data should be sent to your server when user has already vaulted his PayPal account (https://developer.paypal.com/braintree/docs/guides/paypal/vault/android/v4#collecting-device-data).
Changes:
- Added native `getDeviceData` methods to only call Data Collector and resolve promise with the result.