### PR TITLE
Feature: 3DS method improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,9 +139,11 @@ RNBraintree.tokenizeCard({
 import RNBraintree from '@ekreative/react-native-braintree';
 
 RNBraintree.run3DSecureCheck({
+    // Optional if you ran `tokenizeCard()` or other Braintree methods before
     clientToken: 'CLIENT_TOKEN_GENERATED_ON_SERVER_SIDE',
     nonce: 'CARD_NONCE',
     amount: '122.00',
+    // Pass as many of the following fields as possible, but they're optional
     email: 'email@mail.com',
     firstname: '',
     lastname: '',
@@ -155,7 +157,6 @@ RNBraintree.run3DSecureCheck({
     })
     .then(result => console.log(result))
     .catch((error) => console.log(error));
-
 ```
 
 ##### Request PayPal billing agreement

--- a/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
+++ b/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
@@ -306,8 +306,12 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
     public void run3DSecureCheck(final ReadableMap parameters, final Promise promise) {
         mPromise = promise;
 
-        if (!parameters.hasKey("clientToken")) {
-            promise.reject("You must provide a clientToken");
+        if (mBraintreeClient == null) {
+            String clientToken = parameters.getString("clientToken");
+            if (!parameters.hasKey("clientToken")) {
+                promise.reject("You must provide a clientToken");
+            }
+            setup(parameters.getString("clientToken"));
         }
 
         setup(parameters.getString("clientToken"));

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,18 +11,21 @@ declare module '@ekreative/react-native-braintree' {
   }
 
   export interface Run3DSecureCheckOptions
-    extends Omit<BraintreeOptions, 'currencyCode'> {
+    extends Omit<BraintreeOptions, "currencyCode" | "clientToken"> {
     nonce: string;
-    email: string;
-    firstname: string;
-    lastname: string;
-    phoneNumber: string;
-    streetAddress: string;
+    /* Pass clientToken if previously no RNBraintree methods were run. */
+    clientToken?: string;
+    /* Provide as many of the following fields as possible. */
+    email?: string;
+    firstname?: string;
+    lastname?: string;
+    phoneNumber?: string;
+    streetAddress?: string;
     streetAddress2?: string;
-    city: string;
+    city?: string;
     region?: string;
-    postalCode: string;
-    countryCode: string;
+    postalCode?: string;
+    countryCode?: string;
   }
 
   export interface TokenizeCardOptions {

--- a/ios/RNBraintree.m
+++ b/ios/RNBraintree.m
@@ -117,7 +117,9 @@ RCT_EXPORT_METHOD(run3DSecureCheck: (NSDictionary *)parameters
                 resolver: (RCTPromiseResolveBlock)resolve
                 rejecter: (RCTPromiseRejectBlock)reject {
     NSString *clientToken = parameters[@"clientToken"];
-    self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
+    if (self.apiClient == NULL) {
+        self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
+    }
     self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];
 
     BTThreeDSecureRequest *threeDSecureRequest = [[BTThreeDSecureRequest alloc] init];

--- a/ios/RNBraintree.m
+++ b/ios/RNBraintree.m
@@ -118,6 +118,9 @@ RCT_EXPORT_METHOD(run3DSecureCheck: (NSDictionary *)parameters
                 rejecter: (RCTPromiseRejectBlock)reject {
     NSString *clientToken = parameters[@"clientToken"];
     if (self.apiClient == NULL) {
+        if (clientToken == NULL) {
+            reject(@"MISSING_CLIENT_TOKEN", @"clientToken must be passed if Braintree methods weren't run before", nil);
+        }
         self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
     }
     self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];


### PR DESCRIPTION
Issues I came across with:
- you had to pass `clientToken` to `run3DSecureCheck()` method. I don't think it should be mandatory, because if any of the Braintree methods were run before, Braintree client was already initialized. So fixed it in both iOS and Android and handled case where promise is rejected if no token is passed
- according to TS you had to pass `email`, `firstname`, `lastname` and other 3DS fields, but actually they're not mandatory, you should just pass as many as you have. Made them optional