### PR TITLE
Add npm,release, native SDK version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <div align="center">
 
-| NPM Version | Package Version | Android SDK | iOS SDK |
+| Published Version | Package Version | Android SDK | iOS SDK |
 |:-----------:|:---------------:|:-----------:|:-------:|
 |[![npm](https://img.shields.io/npm/v/react-native-braintree.svg)](https://www.npmjs.com/package/react-native-braintree) | [v2.4.0](https://github.com/ekreative/react-native-braintree/releases/tag/v2.4.0) | 28 | 12.0 |
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-[![npm](https://img.shields.io/npm/v/react-native-braintree.svg)](https://www.npmjs.com/package/react-native-braintree)
+
+<div align="center">
+
+| NPM Version | Package Version | Android SDK | iOS SDK |
+|---|-----------------|-------------|---------|
+|[![npm](https://img.shields.io/npm/v/react-native-braintree.svg)](https://www.npmjs.com/package/react-native-braintree)   | [v2.4.0](https://github.com/ekreative/react-native-braintree/releases/tag/v2.4.0)           | 28       | 12.0   |
+</div>
 
 # @ekreative/react-native-braintree
 

--- a/README.md
+++ b/README.md
@@ -237,4 +237,5 @@ If you want to read further you can follow these links
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -237,5 +237,4 @@ If you want to read further you can follow these links
 
 <!-- markdownlint-restore -->
 <!-- prettier-ignore-end -->
-
 <!-- ALL-CONTRIBUTORS-LIST:END -->

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 <div align="center">
 
 | NPM Version | Package Version | Android SDK | iOS SDK |
-|---|-----------------|-------------|---------|
-|[![npm](https://img.shields.io/npm/v/react-native-braintree.svg)](https://www.npmjs.com/package/react-native-braintree)   | [v2.4.0](https://github.com/ekreative/react-native-braintree/releases/tag/v2.4.0)           | 28       | 12.0   |
+|:-----------:|:---------------:|:-----------:|:-------:|
+|[![npm](https://img.shields.io/npm/v/react-native-braintree.svg)](https://www.npmjs.com/package/react-native-braintree) | [v2.4.0](https://github.com/ekreative/react-native-braintree/releases/tag/v2.4.0) | 28 | 12.0 |
+
 </div>
+
 
 # @ekreative/react-native-braintree
 


### PR DESCRIPTION
#52 
## Update README.md with Native SDK Versions

This PR updates the README.md to display the native SDK versions for both Android and iOS. The table in the README now provides a clear overview of the NPM version, package version (based on release tags), Android SDK, and iOS SDK. 

- Android SDK: 28 (Based on `compileSdkVersion` in the `android/build.gradle` file)
- iOS SDK: 12.0 (Derived from the `IPHONEOS_DEPLOYMENT_TARGET` in the `project.pbxproj` file)

The table content and layout have been centered for better readability.
