### PR TITLE
Upgrade Android Braintree SDK to version 4.41.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,11 +86,11 @@ dependencies {
     //noinspection GradleDynamicVersion
     implementation 'com.facebook.react:react-native:+'  // From node_modules
     implementation 'com.google.android.gms:play-services-wallet:18.1.3'
-    implementation 'com.braintreepayments.api:data-collector:4.38.0'
-    implementation 'com.braintreepayments.api:google-pay:4.38.0'
-    implementation 'com.braintreepayments.api:paypal:4.38.0'
-    implementation 'com.braintreepayments.api:three-d-secure:4.38.0'
-    implementation 'com.braintreepayments.api:card:4.38.0'
+    implementation 'com.braintreepayments.api:data-collector:4.41.0'
+    implementation 'com.braintreepayments.api:google-pay:4.41.0'
+    implementation 'com.braintreepayments.api:paypal:4.41.0'
+    implementation 'com.braintreepayments.api:three-d-secure:4.41.0'
+    implementation 'com.braintreepayments.api:card:4.41.0'
 }
 
 def configureReactNativePom(def pom) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ekreative/react-native-braintree",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ekreative/react-native-braintree",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "devDependencies": {
         "branch-name-lint": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@ekreative/react-native-braintree",
   "title": "React Native Braintree",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "node": ">=16",
   "description": "A react native interface for integrating payments using Braintree",
   "main": "index.js",


### PR DESCRIPTION
There is an error that occurs in our React Native app when we try to use a Credit Card for checkout only on Android.

Error message: "Cardinal SDK configure Error"
Error code: "EUNSPECIFIED"

It seems like updating to the latest 4.41.0 Android Braintree SDK version fixed the issue