### PR TITLE
Feature: Add userAction option to showPayPalModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ import RNBraintree from '@ekreative/react-native-braintree';
 RNBraintree.showPayPalModule({
     clientToken: 'CLIENT_TOKEN_GENERATED_ON_SERVER_SIDE',
     amount: '1.0',
-    currencyCode: 'EUR'
+    currencyCode: 'EUR',
+    // Change button text to “Complete Purchase", optional
+    userAction: 'commit',
     })
     .then(result => console.log(result))
     .catch((error) => console.log(error));

--- a/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
+++ b/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
@@ -143,6 +143,9 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
             if (parameters.hasKey("currencyCode")) {
                 currency = parameters.getString("currencyCode");
             }
+            if (parameters.hasKey("userAction") && PayPalCheckoutRequest.USER_ACTION_COMMIT.equals(parameters.getString("userAction"))) {
+                request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
+            }
             if (mCurrentActivity != null) {
                 mPayPalClient = new PayPalClient(mBraintreeClient);
                 PayPalCheckoutRequest request = new PayPalCheckoutRequest(

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,13 +10,6 @@ declare module '@ekreative/react-native-braintree' {
     currencyCode: string;
   }
 
-  export interface PayPalOptions {
-    clientToken: string;
-    amount: string;
-    currencyCode: string;
-    userAction?: 'commit' | '';
-  }
-
   export interface Run3DSecureCheckOptions
     extends Omit<BraintreeOptions, 'currencyCode' | 'clientToken'> {
     nonce: string;
@@ -46,6 +39,10 @@ declare module '@ekreative/react-native-braintree' {
 
   export interface RunApplePayOptions extends BraintreeOptions {
     companyName: string;
+  }
+
+  export interface PayPalOptions extends BraintreeOptions {
+    userAction?: 'commit' | null;
   }
 
   export interface PayPalBillingAgreementOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,13 @@ declare module '@ekreative/react-native-braintree' {
     currencyCode: string;
   }
 
+  export interface PayPalOptions {
+    clientToken: string;
+    amount: string;
+    currencyCode: string;
+    userAction?: 'commit' | '';
+  }
+
   export interface Run3DSecureCheckOptions
     extends Omit<BraintreeOptions, 'currencyCode' | 'clientToken'> {
     nonce: string;
@@ -50,7 +57,7 @@ declare module '@ekreative/react-native-braintree' {
   // Export
 
   interface RNBraintreeModule {
-    showPayPalModule(options: BraintreeOptions): Promise<BraintreeResponse>;
+    showPayPalModule(options: PayPalOptions): Promise<BraintreeResponse>;
     runGooglePay(options: BraintreeOptions): Promise<BraintreeResponse>;
     run3DSecureCheck(
       options: Run3DSecureCheckOptions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -42,7 +42,7 @@ declare module '@ekreative/react-native-braintree' {
   }
 
   export interface PayPalOptions extends BraintreeOptions {
-    userAction?: 'commit' | null;
+    userAction?: 'commit';
   }
 
   export interface PayPalBillingAgreementOptions {

--- a/ios/RNBraintree.m
+++ b/ios/RNBraintree.m
@@ -50,6 +50,7 @@ RCT_EXPORT_METHOD(requestPayPalBillingAgreement: (NSDictionary *)options
                   rejecter: (RCTPromiseRejectBlock)reject) {
     NSString *clientToken = options[@"clientToken"];
     NSString *description = options[@"description"];
+    NSString *userAction = options[@"userAction"];
 
     self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
     self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];
@@ -58,6 +59,9 @@ RCT_EXPORT_METHOD(requestPayPalBillingAgreement: (NSDictionary *)options
     BTPayPalVaultRequest *request= [[BTPayPalVaultRequest alloc] init];
     if (description) {
         request.billingAgreementDescription = description;
+    }
+    if (userAction && [@"commit" isEqualToString:userAction]) {
+        request.userAction = BTPayPalRequestUserActionCommit;
     }
     [payPalDriver tokenizePayPalAccountWithPayPalRequest:request completion:^(BTPayPalAccountNonce * _Nullable tokenizedPayPalAccount, NSError * _Nullable error) {
         if (error) {


### PR DESCRIPTION
Adds the ability to optionally pass a `userAction` of `"commit"` to the `showPayPalModule` method. The default behavior is unchanged.

* [Android documentation](https://braintree.github.io/braintree_android/PayPalNativeCheckout/com.braintreepayments.api/-pay-pal-native-checkout-request/index.html)
* [iOS documentation](https://braintree.github.io/braintree_ios/current/Classes/BTPayPalCheckoutRequest.html#/c:@M@BraintreePayPal@objc(cs)BTPayPalCheckoutRequest(py)userAction)