### PR TITLE
chore: Upgrade Android dependencies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -84,13 +84,13 @@ repositories {
 
 dependencies {
     //noinspection GradleDynamicVersion
-    implementation 'com.facebook.react:react-native:+'  // From node_modules
-    implementation 'com.google.android.gms:play-services-wallet:18.1.3'
-    implementation 'com.braintreepayments.api:data-collector:4.41.0'
-    implementation 'com.braintreepayments.api:google-pay:4.41.0'
-    implementation 'com.braintreepayments.api:paypal:4.41.0'
-    implementation 'com.braintreepayments.api:three-d-secure:4.41.0'
-    implementation 'com.braintreepayments.api:card:4.41.0'
+    implementation 'com.facebook.react:react-native:+' // From node_modules
+    implementation 'com.google.android.gms:play-services-wallet:19.4.0'
+    implementation 'com.braintreepayments.api:data-collector:4.49.1'
+    implementation 'com.braintreepayments.api:google-pay:4.49.1'
+    implementation 'com.braintreepayments.api:paypal:4.49.1'
+    implementation 'com.braintreepayments.api:three-d-secure:4.49.1'
+    implementation 'com.braintreepayments.api:card:4.49.1'
 }
 
 def configureReactNativePom(def pom) {


### PR DESCRIPTION
We’ve been using this patch locally in production for a few months. Everything has been working as intended.