### PR TITLE
fix: Fix build issue with both iOS and Android

### DIFF
--- a/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
+++ b/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
@@ -143,9 +143,6 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
             if (parameters.hasKey("currencyCode")) {
                 currency = parameters.getString("currencyCode");
             }
-            if (parameters.hasKey("userAction") && PayPalCheckoutRequest.USER_ACTION_COMMIT.equals(parameters.getString("userAction"))) {
-                request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
-            }
             if (mCurrentActivity != null) {
                 mPayPalClient = new PayPalClient(mBraintreeClient);
                 PayPalCheckoutRequest request = new PayPalCheckoutRequest(
@@ -153,6 +150,9 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
                 );
                 request.setCurrencyCode(currency);
                 request.setIntent(PayPalPaymentIntent.AUTHORIZE);
+                if (parameters.hasKey("userAction") && PayPalCheckoutRequest.USER_ACTION_COMMIT.equals(parameters.getString("userAction"))) {
+                       request.setUserAction(PayPalCheckoutRequest.USER_ACTION_COMMIT);
+                }
                 mPayPalClient.tokenizePayPalAccount(
                         mCurrentActivity,
                         request,

--- a/ios/RNBraintree.m
+++ b/ios/RNBraintree.m
@@ -21,6 +21,7 @@ RCT_EXPORT_METHOD(showPayPalModule: (NSDictionary *)options
     NSString *clientToken = options[@"clientToken"];
     NSString *amount = options[@"amount"];
     NSString *currencyCode = options[@"currencyCode"];
+    NSString *userAction = options[@"userAction"];
 
     self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
     self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];
@@ -28,6 +29,9 @@ RCT_EXPORT_METHOD(showPayPalModule: (NSDictionary *)options
 
     BTPayPalCheckoutRequest *request= [[BTPayPalCheckoutRequest alloc] initWithAmount:amount];
     request.currencyCode = currencyCode;
+    if (userAction && [@"commit" isEqualToString:userAction]) {
+        request.userAction = BTPayPalRequestUserActionCommit;
+    }
     [payPalDriver tokenizePayPalAccountWithPayPalRequest:request completion:^(BTPayPalAccountNonce * _Nullable tokenizedPayPalAccount, NSError * _Nullable error) {
         if (error) {
             reject(@"ONE_TIME_PAYMENT_FAILED", error.localizedDescription, nil);
@@ -50,7 +54,6 @@ RCT_EXPORT_METHOD(requestPayPalBillingAgreement: (NSDictionary *)options
                   rejecter: (RCTPromiseRejectBlock)reject) {
     NSString *clientToken = options[@"clientToken"];
     NSString *description = options[@"description"];
-    NSString *userAction = options[@"userAction"];
 
     self.apiClient = [[BTAPIClient alloc] initWithAuthorization: clientToken];
     self.dataCollector = [[BTDataCollector alloc] initWithAPIClient:self.apiClient];
@@ -59,9 +62,6 @@ RCT_EXPORT_METHOD(requestPayPalBillingAgreement: (NSDictionary *)options
     BTPayPalVaultRequest *request= [[BTPayPalVaultRequest alloc] init];
     if (description) {
         request.billingAgreementDescription = description;
-    }
-    if (userAction && [@"commit" isEqualToString:userAction]) {
-        request.userAction = BTPayPalRequestUserActionCommit;
     }
     [payPalDriver tokenizePayPalAccountWithPayPalRequest:request completion:^(BTPayPalAccountNonce * _Nullable tokenizedPayPalAccount, NSError * _Nullable error) {
         if (error) {


### PR DESCRIPTION
Hi, @vasylnahuliak. Sorry about this, but I didn’t apply my local patch correctly in #90. The `userAction` was added to the wrong method for iOS and the Android `request` was referenced before it was declared. This PR fixes both issues. Verified by building locally.

iOS:
![ios](https://github.com/user-attachments/assets/86bc602f-d8a0-4dda-b7b0-3135ec1a0f1f)

Android:
![android](https://github.com/user-attachments/assets/29e7bb99-dac5-4002-bb84-3d940fa20f95)

Thanks for your patience.