### PR TITLE
Add support for `appLinkReturnUrl` to showPayPalModule

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ allprojects {
 
 In Your `AndroidManifest.xml`, `android:allowBackup="false"` can be replaced `android:allowBackup="true"`, it is responsible for app backup.
 
-Also, add this intent-filter to your main activity in `AndroidManifest.xml`
+Also, add this intent-filter to your main activity in `AndroidManifest.xml`:
 
 ```xml
 <activity>
@@ -35,8 +35,24 @@ Also, add this intent-filter to your main activity in `AndroidManifest.xml`
         <data android:scheme="${applicationId}.braintree" />
     </intent-filter>
 </activity>
-
 ```
+
+If you need to specify a custom `appLinkReturnUrl`, you may do so:
+
+```xml
+<activity>
+    ...
+    <intent-filter>
+        <action android:name="android.intent.action.VIEW" />
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+        <data android:scheme="${applicationId}.braintree.custom" />
+    </intent-filter>
+</activity>
+```
+
+You will need to pass this value to to `RNBraintree.showPayPalModule` as an option (see **Show PayPall module** below).
+
 **NOTE: Card payments do not work on rooted devices and Android Emulators**
 
 If your project uses Progurad, add the following lines into `proguard-rules.pro` file
@@ -113,6 +129,8 @@ RNBraintree.showPayPalModule({
     currencyCode: 'EUR',
     // Change button text to “Complete Purchase", optional
     userAction: 'commit',
+    // Define a custom return URL for Android, optional
+    appLinkReturnUrl: 'com.application.braintree.custom',
     })
     .then(result => console.log(result))
     .catch((error) => console.log(error));

--- a/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
+++ b/android/src/main/java/com/ekreative/reactnativebraintree/RNBraintreeModule.java
@@ -134,7 +134,11 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
         if (!parameters.hasKey("clientToken")) {
             promise.reject("You must provide a clientToken");
         } else {
-            setup(parameters.getString("clientToken"));
+            if (parameters.hasKey("appLinkReturnUrl")) {
+                setup(parameters.getString("clientToken"), parameters.getString("appLinkReturnUrl"));
+            } else {
+                setup(parameters.getString("clientToken"));
+            }
 
             String currency = "USD";
             if (!parameters.hasKey("amount")) {
@@ -416,6 +420,19 @@ public class RNBraintreeModule extends ReactContextBaseJavaModule
         if (mBraintreeClient == null || !token.equals(mToken)) {
             mCurrentActivity = (FragmentActivity) getCurrentActivity();
             mBraintreeClient = new BraintreeClient(mContext, token);
+
+            new DataCollector(mBraintreeClient).collectDeviceData(
+                    mContext,
+                    (result, e) -> mDeviceData = result);
+            mToken = token;
+
+        }
+    }
+
+    private void setup(final String token, final String appLinkReturnUrl) {
+        if (mBraintreeClient == null || !token.equals(mToken)) {
+            mCurrentActivity = (FragmentActivity) getCurrentActivity();
+            mBraintreeClient = new BraintreeClient(mContext, token, appLinkReturnUrl);
 
             new DataCollector(mBraintreeClient).collectDeviceData(
                     mContext,

--- a/index.d.ts
+++ b/index.d.ts
@@ -43,6 +43,7 @@ declare module '@ekreative/react-native-braintree' {
 
   export interface PayPalOptions extends BraintreeOptions {
     userAction?: 'commit';
+    appLinkReturnUrl?: string,
   }
 
   export interface PayPalBillingAgreementOptions {


### PR DESCRIPTION
Allows specifying a custom return URL for Android when using the PayPal client.

* [Android docs](https://braintree.github.io/braintree_android/PayPal/com.braintreepayments.api.paypal/-pay-pal-client/-pay-pal-client.html)

Built and tested locally by adding this to the `AndroidManifest.xml`:

```xml
<intent-filter>
  <action android:name="android.intent.action.VIEW" />
  <category android:name="android.intent.category.DEFAULT" />
  <category android:name="android.intent.category.BROWSABLE" />
  <data android:scheme="com.example.braintree.paypal" />
</intent-filter>
```

…and passing the same value in the client:

```tsx
const result = await RNBraintree.showPayPalModule({
  appLinkReturnUrl: "com.example.braintree.paypal",
  clientToken,
  userAction: "commit",
  amount,
  currency,
});
```